### PR TITLE
Fix RelData nil pointer deref

### DIFF
--- a/models/manga.go
+++ b/models/manga.go
@@ -97,6 +97,8 @@ func (m *Manga) RelData() (rd *RelData) {
 		return m.relData
 	}
 
+	rd = &RelData{}
+
 	for _, rel := range m.Relationships {
 		switch rel.Type {
 		case "author":


### PR DESCRIPTION
I ran into this error trying to run : `ERROR internal server error error="template: list.tmpl.xml:26:12: executing \"list.tmpl.xml\" at <.RelData>: error calling RelData: runtime error: invalid memory address or nil pointer dereference" path=/catalog/updated`. This seems to fix the issue.